### PR TITLE
Callback

### DIFF
--- a/spec/Callback_spec.js
+++ b/spec/Callback_spec.js
@@ -1,0 +1,11 @@
+'use strict';
+
+describe('Callback', () => {
+  let Callback = require('../src/Callback.js');
+
+  it('toString should return the correct value', () => {
+    expect(new Callback().toString()).toEqual('<callback>');
+
+    expect(String(new Callback())).toEqual('<callback>');
+  });
+});

--- a/spec/Expectation_spec.js
+++ b/spec/Expectation_spec.js
@@ -3,30 +3,25 @@
 describe('Expectation', () => {
   let Expectation = require('../src/Expectation.js');
   let Mock = require('../src/Mock.js');
+  let Callback = require('../src/Callback.js');
 
   it('should initialize with an ExpectedCall and Tree', () => {
     let expectation = new Expectation({
       name: 'foo'
     }, true);
 
-    expect(expectation._expectedCall.name)
-      .toEqual('foo');
-    expect(expectation._tree._root.child.name)
-      .toEqual('foo');
+    expect(expectation._expectedCall.name).toEqual('foo');
+    expect(expectation._tree._root.child.name).toEqual('foo');
   });
 
   it('should set expected call required flag as specified', () => {
     expect(new Expectation({
-          name: 'foo'
-        }, true)
-        ._expectedCall.required)
-      .toEqual(true);
+      name: 'foo'
+    }, true)._expectedCall.required).toEqual(true);
 
     expect(new Expectation({
-          name: 'foo'
-        }, false)
-        ._expectedCall.required)
-      .toEqual(false);
+      name: 'foo'
+    }, false)._expectedCall.required).toEqual(false);
   });
 
   it('withTheseArguments should set expected call arguments', () => {
@@ -36,15 +31,13 @@ describe('Expectation', () => {
       name: 'foo'
     });
 
-    expect(expectation._expectedCall.expectedArgs.length)
-      .toEqual(0);
+    expect(expectation._expectedCall.expectedArgs.length).toEqual(0);
 
     expectation.withTheseArguments(0, 1, 2, 3);
 
-    expect(expectation._expectedCall.expectedArgs.length)
-      .toEqual(args.length);
+    expect(expectation._expectedCall.expectedArgs.length).toEqual(args.length);
 
-    for (let i = 0; i < args.length; i++) {
+    for(let i = 0; i < args.length; i++) {
       expect(expectation._expectedCall.expectedArgs[i]).toEqual(args[i]);
     }
   });
@@ -54,13 +47,11 @@ describe('Expectation', () => {
       name: 'foo'
     });
 
-    expect(expectation._expectedCall.checkArgs)
-      .toBe(true);
+    expect(expectation._expectedCall.checkArgs).toBe(true);
 
     expectation.withAnyArguments();
 
-    expect(expectation._expectedCall.checkArgs)
-      .toEqual(false);
+    expect(expectation._expectedCall.checkArgs).toEqual(false);
   });
 
   it('andWillReturn should set expected call return value', () => {
@@ -68,13 +59,11 @@ describe('Expectation', () => {
       name: 'foo'
     });
 
-    expect(expectation._expectedCall.returnValue)
-      .toBeUndefined();
+    expect(expectation._expectedCall.returnValue).toBeUndefined();
 
     expectation.andWillReturn(0);
 
-    expect(expectation._expectedCall.returnValue)
-      .toEqual(0);
+    expect(expectation._expectedCall.returnValue).toEqual(0);
   });
 
   it('andWillThrow should set expected call throw value', () => {
@@ -84,13 +73,11 @@ describe('Expectation', () => {
 
     let error = new Error('oh noes');
 
-    expect(expectation._expectedCall.throwValue)
-      .toBeUndefined();
+    expect(expectation._expectedCall.throwValue).toBeUndefined();
 
     expectation.andWillThrow(error);
 
-    expect(expectation._expectedCall.throwValue)
-      .toEqual(error);
+    expect(expectation._expectedCall.throwValue).toEqual(error);
   });
 
   it('and should merge the expectations trees', () => {
@@ -105,10 +92,8 @@ describe('Expectation', () => {
     a.and(b);
 
     let expectedTree = '{ ROOT [{ AND {{ a, b }} [{ TERMINUS }] }] }';
-    expect(a._tree.toString())
-      .toEqual(expectedTree);
-    expect(b._tree.toString())
-      .toEqual(expectedTree);
+    expect(a._tree.toString()).toEqual(expectedTree);
+    expect(b._tree.toString()).toEqual(expectedTree);
   });
 
   it('then should merge the expectations tree', () => {
@@ -123,10 +108,8 @@ describe('Expectation', () => {
     a.then(b);
 
     let expectedTree = '{ ROOT [{ a [{ b [{ TERMINUS }] }] }] }';
-    expect(a._tree.toString())
-      .toEqual(expectedTree);
-    expect(b._tree.toString())
-      .toEqual(expectedTree);
+    expect(a._tree.toString()).toEqual(expectedTree);
+    expect(b._tree.toString()).toEqual(expectedTree);
   });
 
   it('multipleTimes should chain same expectation multiple times', () => {
@@ -135,36 +118,29 @@ describe('Expectation', () => {
     });
 
     a.multipleTimes(-1);
-    expect(a._tree.toString())
-      .toEqual('{ ROOT [{ a [{ TERMINUS }] }] }');
+    expect(a._tree.toString()).toEqual('{ ROOT [{ a [{ TERMINUS }] }] }');
 
     a.multipleTimes(0);
-    expect(a._tree.toString())
-      .toEqual('{ ROOT [{ a [{ TERMINUS }] }] }');
+    expect(a._tree.toString()).toEqual('{ ROOT [{ a [{ TERMINUS }] }] }');
 
     a.multipleTimes(1);
-    expect(a._tree.toString())
-      .toEqual('{ ROOT [{ a [{ TERMINUS }] }] }');
+    expect(a._tree.toString()).toEqual('{ ROOT [{ a [{ TERMINUS }] }] }');
 
     a.multipleTimes(2);
-    expect(a._tree.toString())
-      .toEqual('{ ROOT [{ AND {{ a, a }} [{ TERMINUS }] }] }');
+    expect(a._tree.toString()).toEqual('{ ROOT [{ AND {{ a, a }} [{ TERMINUS }] }] }');
 
     a.multipleTimes(3);
-    expect(a._tree.toString())
-      .toEqual('{ ROOT [{ AND {{ a, a, a, a }} [{ TERMINUS }] }] }');
+    expect(a._tree.toString()).toEqual('{ ROOT [{ AND {{ a, a, a, a }} [{ TERMINUS }] }] }');
   });
 
   it('andOtherCallsShouldBeIgnored should set tree property', () => {
     let expectation = new Expectation(new Mock('mock')._class, true);
 
-    expect(expectation._tree._ignoreOtherCalls)
-      .toBe(false);
+    expect(expectation._tree._ignoreOtherCalls).toBe(false);
 
     expectation.andOtherCallsShouldBeIgnored();
 
-    expect(expectation._tree._ignoreOtherCalls)
-      .toBe(true);
+    expect(expectation._tree._ignoreOtherCalls).toBe(true);
   });
 
   it('when should execute the expecation chain', () => {
@@ -172,13 +148,74 @@ describe('Expectation', () => {
     let b = new Mock('b');
     let c = new Mock('c');
 
-    a.shouldBeCalled()
-      .and(b.shouldBeCalled())
-      .then(c.shouldBeCalled())
+    a.shouldBeCalled().and(b.shouldBeCalled()).then(c.shouldBeCalled())
       .when(() => {
         b();
         a();
         c();
       });
+  });
+
+  describe('andWillCallback', () => {
+    let expectation;
+
+    beforeEach(() => {
+      expectation = new Expectation({
+        name: 'foo'
+      });
+    });
+
+    it('should throw an error if no arguments were defined', () => {
+      expect(() => expectation.andWillCallback())
+        .toThrowError('expectation has no arguments to callback');
+    });
+
+    it('should throw an error if no callback argument was defined', () => {
+      expectation.withTheseArguments(0);
+
+      expect(() => expectation.andWillCallback())
+        .toThrowError('expectation has no callback argument');
+    });
+
+    it('should throw an error if a return value is defined', () => {
+      expectation.andWillReturn(0);
+
+      expect(() => expectation.andWillCallback())
+        .toThrowError('expectation can not have return value and callback');
+    });
+
+    it('andWillReturn should throw and error if a callback is defined', () => {
+      expectation.withTheseArguments(new Callback());
+
+      expectation.andWillCallback();
+
+      expect(() => expectation.andWillReturn())
+        .toThrowError('expectation can not have return value and callback');
+    });
+
+    it('should set callback value', () => {
+      expect(expectation._expectedCall.callback).toBeUndefined();
+      expect(expectation._expectedCall.callbackArgs.length).toEqual(0);
+
+      expectation.withTheseArguments(new Callback());
+
+      expectation.andWillCallback();
+
+      expect(expectation._expectedCall.callback).toBeDefined();
+      expect(expectation._expectedCall.callbackArgs.length).toEqual(0);
+
+    });
+
+    it('should set callback value with arguments', () => {
+      expect(expectation._expectedCall.callback).toBeUndefined();
+      expect(expectation._expectedCall.callbackArgs.length).toEqual(0);
+
+      expectation.withTheseArguments(new Callback());
+
+      expectation.andWillCallback(0);
+
+      expect(expectation._expectedCall.callback).toBeDefined();
+      expect(expectation._expectedCall.callbackArgs).toEqual([0]);
+    });
   });
 });

--- a/spec/Expectation_spec.js
+++ b/spec/Expectation_spec.js
@@ -194,27 +194,27 @@ describe('Expectation', () => {
     });
 
     it('should set callback value', () => {
-      expect(expectation._expectedCall.callback).toBeUndefined();
+      expect(expectation._expectedCall.callbackIndex).toEqual(-1);
       expect(expectation._expectedCall.callbackArgs.length).toEqual(0);
 
       expectation.withTheseArguments(new Callback());
 
       expectation.andWillCallback();
 
-      expect(expectation._expectedCall.callback).toBeDefined();
+      expect(expectation._expectedCall.callbackIndex).toEqual(0);
       expect(expectation._expectedCall.callbackArgs.length).toEqual(0);
 
     });
 
     it('should set callback value with arguments', () => {
-      expect(expectation._expectedCall.callback).toBeUndefined();
+      expect(expectation._expectedCall.callbackIndex).toEqual(-1);
       expect(expectation._expectedCall.callbackArgs.length).toEqual(0);
 
       expectation.withTheseArguments(new Callback());
 
       expectation.andWillCallback(0);
 
-      expect(expectation._expectedCall.callback).toBeDefined();
+      expect(expectation._expectedCall.callbackIndex).toEqual(0);
       expect(expectation._expectedCall.callbackArgs).toEqual([0]);
     });
   });

--- a/spec/Expectation_spec.js
+++ b/spec/Expectation_spec.js
@@ -37,7 +37,7 @@ describe('Expectation', () => {
 
     expect(expectation._expectedCall.expectedArgs.length).toEqual(args.length);
 
-    for(let i = 0; i < args.length; i++) {
+    for (let i = 0; i < args.length; i++) {
       expect(expectation._expectedCall.expectedArgs[i]).toEqual(args[i]);
     }
   });
@@ -203,7 +203,6 @@ describe('Expectation', () => {
 
       expect(expectation._expectedCall.callbackIndex).toEqual(0);
       expect(expectation._expectedCall.callbackArgs.length).toEqual(0);
-
     });
 
     it('should set callback value with arguments', () => {

--- a/spec/ExpectedCall_spec.js
+++ b/spec/ExpectedCall_spec.js
@@ -109,7 +109,6 @@ describe('ExpectedCall', () => {
 
       expect(expectedCall.matchesArguments([0])).toBe(false);
       expect(expectedCall.matchesArguments([() => {}])).toBe(true);
-
     });
 
     it('should use basic equality to validate an argument', () => {

--- a/spec/Tree/AndNode_spec.js
+++ b/spec/Tree/AndNode_spec.js
@@ -74,8 +74,8 @@ describe('AndNode', () => {
 
       a.merge(b);
 
-      for (let expectedCall of a.expectedCalls) {
-        expectedCall.complete([]);
+      for(let expectedCall of a.expectedCalls) {
+        expectedCall.execute([]);
       }
 
       expect(a.match(mock._class, [])).toBeUndefined();
@@ -100,63 +100,35 @@ describe('AndNode', () => {
   });
 
   describe('partialMatch', () => {
-    it('should return undefined if all the calls are completed', () => {
+    it('should return false if all the calls are completed', () => {
       let mock = new Mock('mock');
       let a = new AndNode(new ExpectedCall(mock._class, [], true, false));
       let b = new AndNode(new ExpectedCall(mock._class, [], true, false));
 
       a.merge(b);
 
-      for (let expectedCall of a.expectedCalls) {
-        expectedCall.complete([]);
+      for(let expectedCall of a.expectedCalls) {
+        expectedCall.execute([]);
       }
 
-      expect(a.partialMatch(mock, [])).toBeUndefined();
+      expect(a.partialMatch(mock, [])).toBe(false);
     });
 
-    it('should return undefined if no expected calls match', () => {
+    it('should return false if no expected calls match', () => {
       let mock = new Mock('mock');
       let a = new AndNode(new ExpectedCall(new Mock('a')._class, [], true, true));
       let b = new AndNode(new ExpectedCall(new Mock('b')._class, [], true, true));
 
       a.merge(b);
 
-      expect(a.partialMatch(mock, [])).toBeUndefined();
+      expect(a.partialMatch(mock, [])).toBe(false);
     });
 
     it('should return an expected call if the expected call matches', () => {
       let mock = new Mock('mock');
       let a = new AndNode(new ExpectedCall(mock._class, [], true, true));
 
-      expect(a.partialMatch(mock._class, [])).not.toBeUndefined();
-    });
-  });
-
-  describe('allDone', () => {
-    it('should return false if not all calls are done', () => {
-      let mock = new Mock('mock');
-      let a = new AndNode(new ExpectedCall(mock._class, [], true, false));
-      let b = new AndNode(new ExpectedCall(mock._class, [], true, false));
-
-      a.merge(b);
-
-      a.expectedCalls[0].complete([]);
-
-      expect(a.allDone()).toBe(false);
-    });
-
-    it('should return true if all calls are done', () => {
-      let mock = new Mock('mock');
-      let a = new AndNode(new ExpectedCall(mock._class, [], true, false));
-      let b = new AndNode(new ExpectedCall(mock._class, [], true, false));
-
-      a.merge(b);
-
-      for (let expectedCall of a.expectedCalls) {
-        expectedCall.complete([]);
-      }
-
-      expect(a.allDone()).toBe(true);
+      expect(a.partialMatch(mock._class, [])).toBe(true);
     });
   });
 
@@ -168,8 +140,8 @@ describe('AndNode', () => {
 
       a.merge(b);
 
-      for (let expectedCall of a.expectedCalls) {
-        expectedCall.complete([]);
+      for(let expectedCall of a.expectedCalls) {
+        expectedCall.execute([]);
       }
 
       expect(a.onlyOptionalRemain()).toBe(true);
@@ -182,7 +154,7 @@ describe('AndNode', () => {
 
       a.merge(b);
 
-      a.expectedCalls[0].complete([]);
+      a.expectedCalls[0].execute([]);
 
       expect(a.onlyOptionalRemain()).toBe(false);
     });
@@ -194,7 +166,7 @@ describe('AndNode', () => {
 
       a.merge(b);
 
-      a.expectedCalls[0].complete([]);
+      a.expectedCalls[0].execute([]);
 
       expect(a.onlyOptionalRemain()).toBe(true);
     });

--- a/spec/mach_spec.js
+++ b/spec/mach_spec.js
@@ -748,12 +748,34 @@ describe('mach.js', () => {
           return new Promise((resolve) => {
             a(0);
             resolve();
-          })
+          });
         })
         .then(() => fail('should have rejected'))
         .catch((error) => {
           expect(error.message)
             .toEqual('Unexpected arguments (0) provided to function a\nIncomplete calls:\n\ta(<callback>)');
+          done();
+        });
+    });
+
+    it('should throw a mach error if callback passed in incorrectly at runtime', (done) => {
+      let expectedError = 'Unexpected arguments (0, () => {\n' +
+        '              resolve();\n' +
+        '            }) provided to function a\n' +
+        'Incomplete calls:\n' +
+        '\ta(<callback>, 0)';
+
+      a.shouldBeCalledWith(mach.callback, 0).andWillCallback()
+        .when(() => {
+          return new Promise((resolve) => {
+            a(0, () => {
+              resolve();
+            });
+          });
+        })
+        .then(() => fail('should have rejected'))
+        .catch((error) => {
+          expect(error.message).toEqual(expectedError);
           done();
         });
     });

--- a/spec/mach_spec.js
+++ b/spec/mach_spec.js
@@ -680,6 +680,40 @@ describe('mach.js', () => {
     });
   });
 
+  describe('callback expectations', () => {
+    it('should allow an expectation to have a callback', (done) => {
+      a.shouldBeCalledWith(mach.callback).andWillCallback()
+        .when(() => {
+          return new Promise((resolve) => {
+            a(() => {
+              resolve(1);
+            });
+          });
+        })
+        .catch(fail)
+        .then((value) => {
+          expect(value).toEqual(1);
+          done();
+        });
+    });
+
+    it('should allow an expectation to have a callback with arguments', (done) => {
+      a.shouldBeCalledWith(mach.callback).andWillCallback(0, 1, 2)
+        .when(() => {
+          return new Promise((resolve) => {
+            a((...args) => {
+              resolve(args.reduce((p, c) => p + c));
+            });
+          });
+        })
+        .catch(fail)
+        .then((value) => {
+          expect(value).toEqual(3);
+          done();
+        });
+    });
+  });
+
   describe('async tests', () => {
     it('should allow callbacks in thunks', (done) => {
       a.shouldBeCalled()

--- a/src/Callback.js
+++ b/src/Callback.js
@@ -1,0 +1,9 @@
+'use strict';
+
+class Callback {
+  toString() {
+    return '<callback>';
+  }
+}
+
+module.exports = Callback;

--- a/src/Callback.js
+++ b/src/Callback.js
@@ -4,7 +4,6 @@
  * Represents a callback argument that matches against functions.
  */
 class Callback {
-
   /**
    * Returns string representation of this object.
    * @returns {string} string representation of this object.

--- a/src/Callback.js
+++ b/src/Callback.js
@@ -1,6 +1,14 @@
 'use strict';
 
+/**
+ * Represents a callback argument that matches against functions.
+ */
 class Callback {
+
+  /**
+   * Returns string representation of this object.
+   * @returns {string} string representation of this object.
+   */
   toString() {
     return '<callback>';
   }

--- a/src/Expectation.js
+++ b/src/Expectation.js
@@ -47,7 +47,7 @@ class Expectation {
    * @returns {Expectation} This expectation, which allows chaining.
    */
   andWillReturn(returnValue) {
-    if(this._expectedCall.callback !== undefined) {
+    if(this._expectedCall.callbackIndex !== -1) {
       throw new Error('expectation can not have return value and callback');
     }
 
@@ -67,6 +67,11 @@ class Expectation {
     return this;
   }
 
+  /**
+   * Updates this expectations {@link ExpectedCall} to invoke a callback.
+   * @param  {object[]} [...args] Arguments that will be passed to the callback when it is invoked.
+   * @returns {Expectation} This expectation, which allows chaining.
+   */
   andWillCallback(...args) {
     if(this._expectedCall.returnValue !== undefined) {
       throw new Error('expectation can not have return value and callback');
@@ -76,20 +81,22 @@ class Expectation {
       throw new Error('expectation has no arguments to callback');
     }
 
-    let callback;
+    let callbackIndex = -1;
 
+    let i = 0;
     for(let argument of this._expectedCall.expectedArgs) {
       if(argument instanceof Callback) {
-        callback = argument;
+        callbackIndex = i;
         break;
       }
+      i++;
     }
 
-    if(callback === undefined) {
+    if(callbackIndex === -1) {
       throw new Error('expectation has no callback argument');
     }
 
-    this._expectedCall.callback = callback;
+    this._expectedCall.callbackIndex = callbackIndex;
     this._expectedCall.callbackArgs = args;
 
     return this;

--- a/src/Tree/AndNode.js
+++ b/src/Tree/AndNode.js
@@ -40,7 +40,7 @@ class AndNode extends Node {
   get name() {
     let calls = [];
 
-    for (let expectedCall of this.expectedCalls) {
+    for(let expectedCall of this.expectedCalls) {
       calls.push(expectedCall.name);
     }
 
@@ -53,17 +53,17 @@ class AndNode extends Node {
    */
   merge(node) {
     let andNode;
-    if (node instanceof ExpectedCallNode) {
+    if(node instanceof ExpectedCallNode) {
       andNode = new AndNode(node.expectedCall);
     }
-    else if (node instanceof AndNode) {
+    else if(node instanceof AndNode) {
       andNode = node;
     }
     else {
       throw new Error('Unexpected type for node, expected AndNode or ExpectedCallNode');
     }
 
-    for (let expectedCall of andNode.expectedCalls) {
+    for(let expectedCall of andNode.expectedCalls) {
       this.expectedCalls.push(expectedCall);
     }
   }
@@ -75,12 +75,12 @@ class AndNode extends Node {
    * @return {ExpectedCall|undefined} The matching {@link ExpectedCall} if found; otherwise undefined.
    */
   match(mock, args) {
-    for (let expectedCall of this.expectedCalls) {
-      if (expectedCall.completed) {
+    for(let expectedCall of this.expectedCalls) {
+      if(expectedCall.completed) {
         continue;
       }
 
-      if (expectedCall.matches(mock, args)) {
+      if(expectedCall.matches(mock, args)) {
         return expectedCall;
       }
     }
@@ -91,34 +91,20 @@ class AndNode extends Node {
   /**
    * Determines the the {@link Mock} partially matches any {@link ExpectedCall}s in this node.
    * @param {Mock} mock Mock that was called.
-   * @return {ExpectedCall|undefined} The matching expected call if found; otherwise undefined.
+   * @return {boolean} True if the mock partially matches; otherwise false.
    */
   partialMatch(mock) {
-    for (let expectedCall of this.expectedCalls) {
-      if (expectedCall.completed) {
+    for(let expectedCall of this.expectedCalls) {
+      if(expectedCall.completed) {
         continue;
       }
 
-      if (expectedCall.matchesFunction(mock)) {
-        return expectedCall;
+      if(expectedCall.matchesFunction(mock)) {
+        return true;
       }
     }
 
-    return undefined;
-  }
-
-  /**
-   * Checks to see if all {@link ExpectedCall}s in this node have been completed.
-   * @return {boolean} True if all calls are completed; otherwise false.
-   */
-  allDone() {
-    for (let expectedCall of this.expectedCalls) {
-      if (!expectedCall.completed) {
-        return false;
-      }
-    }
-
-    return true;
+    return false;
   }
 
   /**
@@ -126,12 +112,12 @@ class AndNode extends Node {
    * @return {boolean} True if all incomplete calls are optional; otherwise false.
    */
   onlyOptionalRemain() {
-    for (let expectedCall of this.expectedCalls) {
-      if (expectedCall.completed) {
+    for(let expectedCall of this.expectedCalls) {
+      if(expectedCall.completed) {
         continue;
       }
 
-      if (expectedCall.required) {
+      if(expectedCall.required) {
         return false;
       }
     }

--- a/src/Tree/ExpectedCallNode.js
+++ b/src/Tree/ExpectedCallNode.js
@@ -21,6 +21,15 @@ class ExpectedCallNode extends Node {
      */
     this.expectedCall = expectedCall;
   }
+
+  /**
+   * Determines the the {@link Mock} partially matches the {@link ExpectedCall} in this node.
+   * @param {Mock} mock Mock that was called.
+   * @return {boolean} True if the mock partially matches; otherwise false.
+   */
+  partialMatch(mock) {
+    return this.expectedCall.matchesFunction(mock);
+  }
 }
 
 module.exports = ExpectedCallNode;

--- a/src/mach.js
+++ b/src/mach.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var Any = require('./Any.js');
-var Expectation = require('./Expectation.js');
-var Mock = require('./Mock.js');
-var MockObject = require('./MockObject.js');
-var Same = require('./Same.js');
+let Any = require('./Any.js');
+let Callback = require('./Callback.js');
+let Expectation = require('./Expectation.js');
+let Mock = require('./Mock.js');
+let MockObject = require('./MockObject.js');
+let Same = require('./Same.js');
 
 /**
  * mach.js
@@ -18,7 +19,7 @@ class Mach {
   static mockFunction(thing) {
     let name;
 
-    if (typeof thing === 'function') {
+    if(typeof thing === 'function') {
       name = thing.name;
     }
     else {
@@ -59,6 +60,14 @@ class Mach {
    */
   static get any() {
     return new Any();
+  }
+
+  /**
+   * Creates a new {@link Callback} used as an expected argument for a {@link Mock} expectation that has a callback.
+   * @returns {Callback} Callback
+   */
+  static get callback() {
+    return new Callback();
   }
 
   /**


### PR DESCRIPTION
Expectations now have the option to invoke a callback instead of merely returning a value synchronously or throwing an error.
