### PR TITLE
Added alias for andOtherCallsShouldBeIgnored

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ f.shouldBeCalled().andOtherCallsShouldBeIgnored().when(function() {
 });
 ```
 
+```javascript
+var mach = require('mach');
+
+var f = mach.mockFunction();
+
+f.shouldBeCalled().withOtherCallsIgnored().when(function() {
+  f();
+  f(1);
+});
+```
+
 ## Returning Values
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mach.js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Simple mocking framework for JavaScript inspired by CppUMock and designed for readability",
   "main": "index.js",
   "scripts": {

--- a/spec/Expectation_spec.js
+++ b/spec/Expectation_spec.js
@@ -143,6 +143,16 @@ describe('Expectation', () => {
     expect(expectation._tree._ignoreOtherCalls).toBe(true);
   });
 
+  it('withOtherCallsIgnored should set tree property', () => {
+    let expectation = new Expectation(new Mock('mock')._class, true);
+
+    expect(expectation._tree._ignoreOtherCalls).toBe(false);
+
+    expectation.withOtherCallsIgnored();
+
+    expect(expectation._tree._ignoreOtherCalls).toBe(true);
+  });
+
   it('when should execute the expecation chain', () => {
     let a = new Mock('a');
     let b = new Mock('b');

--- a/spec/mach_spec.js
+++ b/spec/mach_spec.js
@@ -171,8 +171,7 @@ describe('mach.js', () => {
       mock();
     });
 
-    f = () => {};
-    mock = mach.mockFunction(f);
+    mock = mach.mockFunction(() => {});
 
     shouldFailWith('Unexpected function call <anonymous>()', () => {
       mock();

--- a/spec/mach_spec.js
+++ b/spec/mach_spec.js
@@ -657,6 +657,11 @@ describe('mach.js', () => {
       b();
       c();
     });
+
+    b.shouldBeCalled().withOtherCallsIgnored().when(() => {
+      b();
+      c();
+    });
   });
 
   it('should allow mocked calls to be ignored', () => {

--- a/src/Expectation.js
+++ b/src/Expectation.js
@@ -164,6 +164,10 @@ class Expectation {
     return this;
   }
 
+  withOtherCallsIgnored() {
+    return this.andOtherCallsShouldBeIgnored();
+  }
+
   /**
    * Executes the test code and verifies the expectations that were built up.
    * @param {function} thunk Test code.
@@ -179,7 +183,5 @@ class Expectation {
     return this.when(thunk);
   }
 }
-
-Expectation.prototype.withOtherCallsIgnored = Expectation.prototype.andOtherCallsShouldBeIgnored;
 
 module.exports = Expectation;

--- a/src/Expectation.js
+++ b/src/Expectation.js
@@ -165,7 +165,6 @@ class Expectation {
     return this;
   }
 
-
   /**
    * Alias for {@link Expectation#andOtherCallsShouldBeIgnored}
    */

--- a/src/Expectation.js
+++ b/src/Expectation.js
@@ -180,4 +180,6 @@ class Expectation {
   }
 }
 
+Expectation.prototype.withOtherCallsIgnored = Expectation.prototype.andOtherCallsShouldBeIgnored;
+
 module.exports = Expectation;

--- a/src/Expectation.js
+++ b/src/Expectation.js
@@ -157,6 +157,7 @@ class Expectation {
 
   /**
    * Makes it so that unexpected calls and out of order calls are ignored and only required calls are checked during execution.
+   * @returns {Expectation} This expectation, which allows chaining.
    */
   andOtherCallsShouldBeIgnored() {
     this._tree.ignoreOtherCalls();
@@ -164,6 +165,10 @@ class Expectation {
     return this;
   }
 
+
+  /**
+   * Alias for {@link Expectation#andOtherCallsShouldBeIgnored}
+   */
   withOtherCallsIgnored() {
     return this.andOtherCallsShouldBeIgnored();
   }

--- a/src/mach.js
+++ b/src/mach.js
@@ -72,7 +72,7 @@ class Mach {
 
   /**
    * Creates a scope in which unexpected and out of order function calls are ignored and only required calls are checked during execution.
-   * Consider using {@link Expectation#andOtherCallsShouldBeIgnored} instead.
+   * Consider using {@link Expectation#andOtherCallsShouldBeIgnored} or {@link Expectation#withOtherCallsIgnored} instead.
    */
   static ignoreMockedCallsWhen(thunk) {
     let mock = new Mock();


### PR DESCRIPTION
Goal here is to improve readability:

```javascript
f.shouldBeCalled().withOtherCallsIgnored().when(...
```

vs.

```javascript
f.shouldBeCalled().andOtherCallsShouldBeIgnored().when(...
```